### PR TITLE
Add return type declaration to _isAllowed method

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,23 @@
+name: Security
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  composer-audit:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main

--- a/src/app/code/community/Dhl/Versenden/controllers/Adminhtml/Sales/Order/AutocreateController.php
+++ b/src/app/code/community/Dhl/Versenden/controllers/Adminhtml/Sales/Order/AutocreateController.php
@@ -64,7 +64,7 @@ class Dhl_Versenden_Adminhtml_Sales_Order_AutocreateController extends Mage_Admi
         $this->_redirect('adminhtml/sales_order');
     }
 
-    protected function _isAllowed()
+    protected function _isAllowed(): bool
     {
         return Mage::getSingleton('admin/session')->isAllowed('admin/sales/order/actions/ship');
     }


### PR DESCRIPTION
For compatibility with OM 20.18

## Summary

Aligns the _isAllowed method declaration with the parent one for compatibility with OM 20.18

```
Fatal error: Declaration of Dhl_Versenden_Adminhtml_Sales_Order_AutocreateController::_isAllowed() must be compatible with Mage_Adminhtml_Controller_Action::_isAllowed(): bool in /app/vendor/dhl/module-versenden-m1/src/app/code/community/Dhl/Versenden/controllers/Adminhtml/Sales/Order/AutocreateController.php on line 67
```

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code quality
- [ ] CI / build / dependencies

## Checklist

- [ ] Commits are signed (`-S`) and signed-off (`--signoff`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Tests added/updated for changed behavior
- [ ] Documentation updated (README, AGENTS.md, CHANGELOG, or inline docs)
- [ ] CI passes (lint, tests, static analysis)

## Test Plan

<!-- How to verify this works? Commands to run, expected output, or manual steps. -->
