### PR TITLE
Fix uncought type error during autocreation of shipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## 2.0.1 - 2026-05-26
 
 ### Added

--- a/src/app/code/community/Dhl/Versenden/Model/Webservice/Builder/Validator.php
+++ b/src/app/code/community/Dhl/Versenden/Model/Webservice/Builder/Validator.php
@@ -28,6 +28,10 @@ class Dhl_Versenden_Model_Webservice_Builder_Validator
         $orderShipment = $shipmentRequest->getOrderShipment();
         $shippingProduct = $shipmentRequest->getData('gk_api_product');
 
+        if (empty($shippingProduct)) {
+            throw new ValidationException("GK API Product is not set" . $orderShipment?->getOrder()?->getIncrementId() ?? "n/a");
+        }
+
         // Extract services from Magento request data (matches ServiceBuilder structure)
         $serviceInfo = $shipmentRequest->getData('services') ?? [];
         $selectedServices = $serviceInfo['shipment_service'] ?? [];

--- a/src/app/code/community/Dhl/Versenden/Model/Webservice/Builder/Validator.php
+++ b/src/app/code/community/Dhl/Versenden/Model/Webservice/Builder/Validator.php
@@ -29,7 +29,7 @@ class Dhl_Versenden_Model_Webservice_Builder_Validator
         $shippingProduct = $shipmentRequest->getData('gk_api_product');
 
         if (empty($shippingProduct)) {
-            throw new ValidationException("GK API Product is not set" . $orderShipment?->getOrder()?->getIncrementId() ?? "n/a");
+            throw new ValidationException("GK API Product is not set for order " . ($orderShipment?->getOrder()?->getIncrementId() ?? "n/a"));
         }
 
         // Extract services from Magento request data (matches ServiceBuilder structure)


### PR DESCRIPTION
Fix `Uncaught TypeError: Dhl\Sdk\ParcelDe\Shipping\RequestBuilder\Shi…pmentOrderRequestBuilder::setShipmentDetails(): Argument #1 () must be of type string, null given` by checking its value in the validator

## Summary

When tryig to autocreate a shipment to a foreign country, an internal server error occurs. This is because gk_api_product checks against the setting in default shipment. Currently, no default shipment for foreign country orders can get set. So this is null, but the next functions require a string. (I used empty() instead of just check against null bc. I think an empty string will also lead to issues later on)

## Type of Change

- [X ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code quality
- [ ] CI / build / dependencies

## Checklist

- [ ] Commits are signed (`-S`) and signed-off (`--signoff`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Tests added/updated for changed behavior
- [ ] Documentation updated (README, AGENTS.md, CHANGELOG, or inline docs)
- [ ] CI passes (lint, tests, static analysis)

## Test Plan

Try to autocreate a shipment to a foreign country => Internal Server Error: ` PHP Fatal error:  Uncaught TypeError: 
Dhl\\Sdk\\ParcelDe\\Shipping\\RequestBuilder\\ShipmentOrderRequestBuilder::setShipmentDetails(): Argument #1 ($productCode) must be of type string, null given,`

With the PR, a graceful error message is set, instead of triggering an internal server error

